### PR TITLE
fix SHA1 for CLI v6.11.2

### DIFF
--- a/cloudfoundry-cli.rb
+++ b/cloudfoundry-cli.rb
@@ -5,7 +5,7 @@ class CloudfoundryCli < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.11.2&source=homebrew'
   version '6.11.2'
-  sha1 'f4bd3687d9fd0f803cb574ecfe9bcd22f3c872d0'
+  sha1 'ec8c6bc1585d620fdf6c42f59acec5368bc3e4b9'
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
```
$ brew update
$ brew upgrade cloudfoundry-cli
==> Upgrading 1 outdated package, with result:
cloudfoundry-cli 6.11.2
==> Upgrading cloudfoundry-cli
==> Downloading https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.11.2&source
Already downloaded: /Library/Caches/Homebrew/cloudfoundry-cli-6.11.2.2&source=homebrew
Error: SHA1 mismatch
Expected: f4bd3687d9fd0f803cb574ecfe9bcd22f3c872d0
Actual: ec8c6bc1585d620fdf6c42f59acec5368bc3e4b9
Archive: /Library/Caches/Homebrew/cloudfoundry-cli-6.11.2.2&source=homebrew
To retry an incomplete download, remove the file above.
```

Verified:

```
$ wget https://cli.run.pivotal.io/stable\?release\=macosx64-binary\&version\=6.11.2\&source\=homebrew -O cloudfoundry-cli-6.11.2
...
$ openssl sha1 cloudfoundry-cli-6.11.2
SHA1(cloudfoundry-cli-6.11.2)= ec8c6bc1585d620fdf6c42f59acec5368bc3e4b9
```