### PR TITLE
Update SHA1

### DIFF
--- a/cloudfoundry-cli.rb
+++ b/cloudfoundry-cli.rb
@@ -5,7 +5,7 @@ class CloudfoundryCli < Formula
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
   url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.12.0&source=homebrew'
   version '6.12.0'
-  sha1 '8dfca97225499195b5ce9bbfb9f38f423fba78c0'
+  sha1 '34083026a2b747ba176c71a3f2b12eb994b2b1c1'
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
I believe the SHA1 is incorrect for the file that is downloaded. I modified my local `.rb` with `34083026a2b747ba176c71a3f2b12eb994b2b1c1` and `/usr/local/binCloud Foundry version` `6.12.0-8c65bbd-2015-06-30T00:05:01+00:00` was downloaded and installed.