### PR TITLE
Homebrew SHA1 Deprecation Warnings

### DIFF
--- a/gemfirexd.rb
+++ b/gemfirexd.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Gemfirexd < Formula
   homepage 'http://www.pivotal.io/big-data/pivotal-gemfire-xd'
   url 'http://download.pivotal.com.s3.amazonaws.com/gemfirexd/1.4.1/Pivotal_GemFireXD_141_b042215_Linux.zip'
-  sha1 'f50d50a117d8aadf481c745fa61c97e45e140e37'
+  sha256 '305fcd374c631e81f5f4965d6fe2f1e491380a4f30219117f50a87850841b35b'
   version "1.4.1"
   
   def install

--- a/greenplum-db.rb
+++ b/greenplum-db.rb
@@ -3,13 +3,13 @@ require 'formula'
 class GreenplumDb < Formula
   homepage 'http://www.pivotal.io/big-data/pivotal-greenplum-database'
   url 'http://dist.vfabric.com.s3.amazonaws.com/greenplum-db-4.2.8.0.tar.gz'
-  sha1 'a26df9bf2649f6083f19a44c42a84065448450a3'
+  sha256'60c925b3ba9e17a0d67b37fdb03d352ee1c4b7a80ebf10095e0ce78b2f3b6d1c'
 
   resource 'gpdbctl' do
     tapdir = File.dirname(__FILE__)
     extdir = File.basename(__FILE__, ".rb")
     url "file:///#{File.join(tapdir, extdir, "gpdbctl")}"
-    sha1 '23e1062dd0a6633c33b8018dd79a206ef0ad2c74'
+    sha256 'b19788663f02ecffd24af61c8445d33b64fbbcacc8ef7820bb1b912bd61472bc'
   end
 
   def install

--- a/greenplum-db.rb
+++ b/greenplum-db.rb
@@ -3,7 +3,7 @@ require 'formula'
 class GreenplumDb < Formula
   homepage 'http://www.pivotal.io/big-data/pivotal-greenplum-database'
   url 'http://dist.vfabric.com.s3.amazonaws.com/greenplum-db-4.2.8.0.tar.gz'
-  sha256'60c925b3ba9e17a0d67b37fdb03d352ee1c4b7a80ebf10095e0ce78b2f3b6d1c'
+  sha256 '60c925b3ba9e17a0d67b37fdb03d352ee1c4b7a80ebf10095e0ce78b2f3b6d1c'
 
   resource 'gpdbctl' do
     tapdir = File.dirname(__FILE__)

--- a/springxd.rb
+++ b/springxd.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Springxd < Formula
   homepage 'http://projects.spring.io/spring-xd/'
   url 'http://repo.spring.io/libs-release/org/springframework/xd/spring-xd/1.3.1.RELEASE/spring-xd-1.3.1.RELEASE-dist.zip' , :using => :curl
-  sha1 'a561dde1fd0b727119b1748c4a0344af344d6467'
+  sha256 '0a2007e9802ea1cb0110f03ee236e502f3e97193efd6d3a0046b721c7edf500b'
   version "1.3.1.RELEASE"
 
   depends_on 'redis' => :optional

--- a/sqlfire.rb
+++ b/sqlfire.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Sqlfire < Formula
   homepage 'http://gopivotal.com/products/pivotal-sqlfire'
   url 'http://download.pivotal.com.s3.amazonaws.com/sqlfire/1.1.2/Pivotal_SQLFire_112_b45732.zip'
-  sha1 '743280517fbf02bb7d38c1748a3a0b6b36cb9d7d'
+  sha256 '4107e9ee5acf246fa633e7314adddb5f9e97ae24857b0a7429625864bc4d851c'
   version "1.1.2"
   
   def install

--- a/tcserver.rb
+++ b/tcserver.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Tcserver < Formula
   homepage 'http://tcserver.docs.pivotal.io/index.html'
   url 'http://public.pivotal.com.s3.amazonaws.com/releases/tcserver/3.1.5.RELEASE/tcserver-3.1.5.RELEASE-developer.tar.gz'
-  sha1 '8a1607e06d523cd2a13ed2ef429cfe494572b762'
+  sha256 '73ad57d4ebc0b323b05e37b53fb3dd4b497e63ed7e19a3b5233e09e7aa9ccd04'
   version "3.1.5"
   
   # logs, lib and temp folder need to exist for base template to work


### PR DESCRIPTION
This pull request updates the sha1 hash of the downloaded artifact in the homebrew formula to a sha256 hash.  This pull request should eliminate the warnings when running brew install or brew fetch. 