### PR TITLE
Add prob_config.sh

### DIFF
--- a/greenplum-db.rb
+++ b/greenplum-db.rb
@@ -41,6 +41,7 @@ class GreenplumDb < Formula
     
     mkdir "#{prefix}/demo"
     cp "gpAux/gpdemo/demo_cluster.sh", "#{prefix}/demo"
+    cp "gpAux/gpdemo/probe_config.sh", "#{prefix}/demo"
     cp "gpAux/gpdemo/lalshell", "#{prefix}/demo"
     cp "gpAux/gpdemo/Makefile", "#{prefix}/demo"
   end


### PR DESCRIPTION
We missed this one, so during `make -C demo` we hit some error message. It won't break the cluster, but with this script, we can see more cluster information.